### PR TITLE
feat: add PanicsWithError

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -173,6 +173,20 @@ func Panics(t testing.TB, fn func(), msgAndArgs ...interface{}) {
 	fn()
 }
 
+// PanicsWithError asserts that the given function panics with the given error.
+func PanicsWithError(tb testing.TB, expected error, fn func(), msgAndArgs ...interface{}) {
+	tb.Helper()
+	defer func() {
+		if value, ok := recover().(error); ok {
+			Equal(tb, expected, value, msgAndArgs...)
+		} else {
+			msg := formatMsgAndArgs("Expected function to panic with error", msgAndArgs...)
+			tb.Fatal(msg)
+		}
+	}()
+	fn()
+}
+
 // NotPanics asserts that the given function does not panic.
 func NotPanics(t testing.TB, fn func(), msgAndArgs ...interface{}) {
 	t.Helper()

--- a/assert_test.go
+++ b/assert_test.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -120,6 +121,22 @@ func TestNotZero(t *testing.T) {
 	assertOk(t, "Slice", func(t testing.TB) {
 		slice := []int{1, 2, 3}
 		NotZero(t, slice)
+	})
+}
+
+func TestPanicsWithError(t *testing.T) {
+	assertOk(t, "PanicsWithError", func(t testing.TB) {
+		PanicsWithError(t, os.ErrNotExist, func() {
+			panic(os.ErrNotExist)
+		})
+	})
+	assertFail(t, "PanicsWithWrongError", func(t testing.TB) {
+		PanicsWithError(t, os.ErrNotExist, func() {
+			panic(os.ErrExist)
+		})
+	})
+	assertFail(t, "DoesNotPanic", func(t testing.TB) {
+		PanicsWithError(t, os.ErrNotExist, func() {})
 	})
 }
 


### PR DESCRIPTION
Firstly, thank you for this amazing library!

I just migrated a large Go project from stretchr/testify to alecthomas/assert in https://github.com/twpayne/chezmoi/pull/2974 and the process was much, much easier than I expected. Almost all of the changes were done with `grep -rl ... | xargs sed ...`.

I did miss a `PanicsWithError` assertion. Although good Go practice states that panics should not cross package lines, there are cases where the standard library uses panics to control flow, for example in `text/template` where panics are used to propagate errors.

This PR adds a `PanicsWithError`.

If you accept this PR, then I would open a follow-up PR to add a `PanicsWithErrorString` function which uses `EqualError` instead of `Equal` to compare errors. The source code is [here](https://github.com/twpayne/chezmoi/pull/2974/files#diff-17b2a619a8eca6fc368fa1fc226c9c3a8ac918a447498de1a9be5fa594b6c3ddR25).