### PR TITLE
Bump GitHub checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV
       - name: Test
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV
       - name: golangci-lint

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ func False(t testing.TB, ok bool, msgAndArgs ...interface{})
 
 ## Evaluation process
 
-Our empircal data of testify usage comes from a monorepo with around 50K lines
+Our empirical data of testify usage comes from a monorepo with around 50K lines
 of tests.
 
 These are the usage counts for all testify functions, normalised to the base


### PR DESCRIPTION
This PR bumps GitHub `checkout` action to its latest version, thus avoiding deprecation warnings as seen e.g. [here] (https://github.com/alecthomas/assert/actions/runs/9786026787).