### PR TITLE
Add SeqContains and NotSeqContains functions

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"iter"
 	"reflect"
 	"strconv"
 	"strings"
@@ -150,6 +151,39 @@ func NotSliceContains[T any](t testing.TB, haystack []T, needle T, msgAndArgs ..
 			t.Fatalf("%s\nNeedle: %s\nHaystack: %s\n", msg, needleRepr, haystackRepr)
 		}
 	}
+}
+
+// SeqContains asserts that "haystack" contains "needle", but only checks, at most,
+// maxChecked items (since a Seq can be infinite). If this is <= 0 there is no limit.
+func SeqContains[T any](t testing.TB, haystack iter.Seq[T], needle T, maxChecked int, msgAndArgs ...interface{}) {
+	t.Helper()
+
+	found := false
+	count := 0
+	haystack(func(item T) bool {
+		if objectsAreEqual(item, needle) {
+			found = true
+			return false
+		}
+
+		if maxChecked > 0 {
+			count++
+			if count >= maxChecked {
+				return false
+			}
+		}
+
+		return true
+	})
+
+	if found {
+		return
+	}
+
+	msg := formatMsgAndArgs("Haystack does not contain needle.", msgAndArgs...)
+	needleRepr := repr.String(needle, repr.Indent("  "))
+	haystackRepr := repr.String(haystack, repr.Indent("  "))
+	t.Fatalf("%s\nNeedle: %s\nHaystack: %s\n", msg, needleRepr, haystackRepr)
 }
 
 // Zero asserts that a value is its zero value.


### PR DESCRIPTION
Given that we have `iter.Seq[T]` now, along with things like `maps.Keys`, which returns an `iter.Seq[T]`, it might be nice to have a `SeqContains` function in this library since it would have fairly broad applicability and allow some niche things that Testify supports (like `Contains` with a map) without polluting the API with niche functions.

For example,

```go
assert.SeqContains(t, maps.Keys(myMap), 0, "foo")
```

is a fairly elegant way to say "has key", without having a highly specialized `HasKey` function.

I added the `maxChecked` parameter because a sequence can be infinite, so in some cases it might be useful to set an upper bound. I wouldn't anticipate this being set to anything other than zero very often, so I'm not married to the idea. Implementing a `Take(n)` function is pretty easy, so maybe people who need that functionality could just do it that way.

I haven't added the negated version or tests because I wasn't sure if this is a desirable addition. Happy to finish it if so.