### PR TITLE
chore: add test for embedded IsZero() implementer

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -4,11 +4,20 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 )
 
 type Data struct {
 	Str string
 	Num int64
+}
+
+type MyTime struct {
+	time.Time
+}
+
+type MyStruct struct {
+	TheTime *MyTime
 }
 
 func TestEqual(t *testing.T) {
@@ -35,6 +44,9 @@ func TestEqual(t *testing.T) {
 	})
 	assertOk(t, "Exclude", func(t testing.TB) {
 		Equal(t, Data{Str: "expected", Num: 1234}, Data{Str: "expected"}, Exclude[int64]())
+	})
+	assertOk(t, "Embedded time.Time", func(t testing.TB) {
+		Equal(t, MyStruct{}, MyStruct{})
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/alecthomas/assert/v2
 go 1.18
 
 require (
-	github.com/alecthomas/repr v0.4.0
+	github.com/alecthomas/repr v0.5.2
 	github.com/hexops/gotextdiff v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
+github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=


### PR DESCRIPTION
I had a failing test in a project I'm working on that I tracked down to what I think is a bug in https://github.com/alecthomas/repr. However, it was exposed by my use of `assert` and I managed to find a simple reproducer test case that exposes the bug so I have sent the PR here.

Basically, it looks like the change around `IsZero()` in v0.5.x of `repr` causes a panic in some cases. I see that you have fixed one such case in `v0.5.2` of `repr`, but that doesn't fix the case that I found in this PR: when comparing a struct with a pointer member that is nil, but has an embedded type that implements `IsZero()` (such as `time.Time`), it will panic.

Reverting to `repr` v0.4.0 allows this test case to pass.

Please let me know if I can provide more info.

Here's the panic you get running this PR:
```
--- FAIL: TestEqual (0.00s)
    --- FAIL: TestEqual/Embedded_time.Time (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x54af89]

goroutine 15 [running]:
testing.tRunner.func1.2({0x5787e0, 0x6f3b30})
	/usr/local/go/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1875 +0x35b
panic({0x5787e0?, 0x6f3b30?})
	/usr/local/go/src/runtime/panic.go:783 +0x132
github.com/alecthomas/assert/v2.(*MyTime).IsZero(0x6f47b0?)
	<autogenerated>:1 +0x9
github.com/alecthomas/repr.(*Printer).reprValue(0xc000013180, 0xc0000e7c78, {0x57d180, 0x0, 0x19}, {0x0, 0x0}, 0x1, 0x0)
	/home/scott/go/pkg/mod/github.com/alecthomas/repr@v0.5.2/repr.go:302 +0x1a66
github.com/alecthomas/repr.(*Printer).Print(0xc000013180, {0xc0000e7d18?, 0x1, 0x1?})
	/home/scott/go/pkg/mod/github.com/alecthomas/repr@v0.5.2/repr.go:175 +0xf5
github.com/alecthomas/repr.String({0x57d180, 0x0}, {0xc0000780f0, 0x1, 0x6c8b28?})
	/home/scott/go/pkg/mod/github.com/alecthomas/repr@v0.5.2/repr.go:402 +0x130
github.com/alecthomas/assert/v2.objectsAreEqual({0x57d180, 0x0}, {0x57d180, 0x0}, {0xc000076618?, 0xc000076620?, 0xc0000765f0?})
	/home/scott/dev/assert/assert.go:358 +0x152
github.com/alecthomas/assert/v2.Equal[...]({0x5e82d0, 0xc00000eb88}, {0xc000076700}, {0x4185e5?}, {0x0?, 0x59fdc0?, 0xc000076601?})
	/home/scott/dev/assert/assert.go:85 +0x365
github.com/alecthomas/assert/v2.TestEqual.func9({0x5e82d0?, 0xc00000eb88?})
	/home/scott/dev/assert/assert_test.go:49 +0x38
github.com/alecthomas/assert/v2.assertOk.func1(0xc0000eac40)
	/home/scott/dev/assert/assert_test.go:259 +0x6c
testing.tRunner(0xc0000eac40, 0xc000026c00)
	/usr/local/go/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 6
	/usr/local/go/src/testing/testing.go:1997 +0x465
FAIL	github.com/alecthomas/assert/v2	0.005s
FAIL
```
